### PR TITLE
Added Semaphore to handle recording and caught unhandled exception.

### DIFF
--- a/Application/src/main/java/com/example/android/camera2video/Camera2VideoFragment.java
+++ b/Application/src/main/java/com/example/android/camera2video/Camera2VideoFragment.java
@@ -312,7 +312,7 @@ public class Camera2VideoFragment extends Fragment
 
     @Override
     public void onClick(View view) {
-        if (!mRecordingLock.tryAcquire(1)) {
+        if (!mRecordingLock.tryAcquire()) {
             return;
         }
         switch (view.getId()) {


### PR DESCRIPTION
I added a semaphore so that when startRecordingVideo/stopRecordingVideo get called, they can't execute more than once.  This was causing multiple issues with the MediaRecorder.

Caught unhandled RuntimeException in mMediaRecorder.Stop() that is thrown when the MediaRecorder is told to stop before it has any valid Video/Audio data.  

This should handle #55 and #86 and possibly other issues.